### PR TITLE
Pass custom props to columns

### DIFF
--- a/src/TableHeaderRow.js
+++ b/src/TableHeaderRow.js
@@ -42,6 +42,7 @@ export class HeaderData extends React.Component {
   state = {
     columns:
       React.Children.map(this.props.children, ({ props }) => ({
+        ...props,
         accessor: props.accessor || false,
         label: props.children,
         sortable: props.sortable || false,

--- a/src/__tests__/TableHeaderRow.test.js
+++ b/src/__tests__/TableHeaderRow.test.js
@@ -83,18 +83,21 @@ describe('HeaderData', () => {
       columns: [
         {
           accessor: 'foo',
+          children: 'Foo',
           label: 'Foo',
           sortable: false,
           filterable: true
         },
         {
           accessor: false,
+          children: 'Nothing',
           label: 'Nothing',
           sortable: false,
           filterable: false
         },
         {
           accessor: 'bar',
+          children: 'Bar',
           label: 'Bar',
           sortable: true,
           filterable: false


### PR DESCRIPTION
Pass any custom properties defined on columns into the calculated columns.
This allows the use of things like adding a 'hidden' property to a column which the render can access.